### PR TITLE
fix: Create Redisson maps and counters on worker thread

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/redis/RedisClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/RedisClusterManager.java
@@ -219,7 +219,8 @@ public class RedisClusterManager implements ClusterManager, NodeInfoCatalogListe
     vertx
         .<RAtomicLong>executeBlocking(
             p -> p.complete(redisson.getAtomicLong(keyFactory.counter(name))))
-        .map(counter -> new RedisCounter(vertx, counter));
+        .<Counter>map(counter -> new RedisCounter(vertx, counter))
+        .onComplete(promise);
   }
 
   @Override


### PR DESCRIPTION
Change to ensure we're not blocking the event loop thread when creating shared Redisson data types.