### PR TITLE
feat: Add BlockingQueue and BlockingDeque support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,20 @@
           </annotationProcessors>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
       <!-- Tests and code coverage -->
       <plugin>
         <groupId>org.jacoco</groupId>

--- a/src/main/java/io/vertx/spi/cluster/redis/RedisClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/RedisClusterManager.java
@@ -390,7 +390,7 @@ public class RedisClusterManager implements ClusterManager, NodeInfoCatalogListe
     if (!isActive()) {
       return Optional.empty();
     }
-    return Optional.of(new RedissonRedisInstance(redisson, config));
+    return Optional.of(new RedissonRedisInstance(redisson, config, keyFactory));
   }
 
   /** A redis semaphore wrapper that supports lock lease time when configured. */

--- a/src/main/java/io/vertx/spi/cluster/redis/RedisInstance.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/RedisInstance.java
@@ -1,5 +1,12 @@
 package io.vertx.spi.cluster.redis;
 
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.spi.cluster.ClusterManager;
+import java.util.Optional;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.BlockingQueue;
+
 /**
  * Low-level access to distributed data types backed by Redis. Prefer Vertx shared data types over
  * using this API.
@@ -9,9 +16,44 @@ package io.vertx.spi.cluster.redis;
 public interface RedisInstance {
 
   /**
+   * Returns the Redis instance from the {@link RedisClusterManager}. If Vertx is not using the
+   * Redis cluster manager an empty optional will be returned.
+   *
+   * @param vertx the vertx instance
+   * @return an optional with the Redis instance.
+   */
+  static Optional<RedisInstance> getInstance(Vertx vertx) {
+    if (vertx instanceof VertxInternal) {
+      ClusterManager clusterManager = ((VertxInternal) vertx).getClusterManager();
+      if (clusterManager instanceof RedisClusterManager) {
+        return ((RedisClusterManager) clusterManager).getRedisInstance();
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
    * Ping the Redis instance(s) to determine availability.
    *
    * @return <code>true</code> if ping is successful, otherwise <code>false</code>.
    */
   boolean ping();
+
+  /**
+   * Returns an unbounded blocking queue backed by Redis.
+   *
+   * @param <V> type of value
+   * @param name name of the queue
+   * @return A blocking queue instance.
+   */
+  <V> BlockingQueue<V> getBlockingQueue(String name);
+
+  /**
+   * Returns an unbounded blocking deque backed by Redis.
+   *
+   * @param <V> tyep of value
+   * @param name name of the deque
+   * @return a blocking deque instance.
+   */
+  <V> BlockingDeque<V> getBlockingDeque(String name);
 }

--- a/src/main/java/io/vertx/spi/cluster/redis/RedisInstance.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/RedisInstance.java
@@ -16,13 +16,13 @@ import java.util.concurrent.BlockingQueue;
 public interface RedisInstance {
 
   /**
-   * Returns the Redis instance from the {@link RedisClusterManager}. If Vertx is not using the
-   * Redis cluster manager an empty optional will be returned.
+   * Create a Redis instance from the {@link RedisClusterManager}. If Vertx is not using the Redis
+   * cluster manager an empty optional will be returned.
    *
    * @param vertx the vertx instance
    * @return an optional with the Redis instance.
    */
-  static Optional<RedisInstance> getInstance(Vertx vertx) {
+  static Optional<RedisInstance> create(Vertx vertx) {
     if (vertx instanceof VertxInternal) {
       ClusterManager clusterManager = ((VertxInternal) vertx).getClusterManager();
       if (clusterManager instanceof RedisClusterManager) {
@@ -51,7 +51,7 @@ public interface RedisInstance {
   /**
    * Returns an unbounded blocking deque backed by Redis.
    *
-   * @param <V> tyep of value
+   * @param <V> type of value
    * @param name name of the deque
    * @return a blocking deque instance.
    */

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/RedisKeyFactory.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/RedisKeyFactory.java
@@ -19,7 +19,7 @@ public class RedisKeyFactory {
     this.hasNamespace = namespace != null && !namespace.isEmpty();
   }
 
-  private String build(String... path) {
+  String build(String... path) {
     String name = String.join(DELIMITER, path);
     return hasNamespace ? namespace + DELIMITER + name : name;
   }

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/RedissonRedisInstance.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/RedissonRedisInstance.java
@@ -3,6 +3,8 @@ package io.vertx.spi.cluster.redis.impl;
 import io.vertx.spi.cluster.redis.RedisInstance;
 import io.vertx.spi.cluster.redis.config.ClientType;
 import io.vertx.spi.cluster.redis.config.RedisConfig;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.BlockingQueue;
 import org.redisson.api.RedissonClient;
 import org.redisson.api.redisnode.RedisNodes;
 
@@ -14,16 +16,20 @@ import org.redisson.api.redisnode.RedisNodes;
 public final class RedissonRedisInstance implements RedisInstance {
   private final RedissonClient redisson;
   private final RedisConfig config;
+  private final RedisKeyFactory keyFactory;
 
   /**
    * Create a new instance.
    *
    * @param redisson redisson client
    * @param config redis cluster manager config
+   * @param keyFactory redis key factory
    */
-  public RedissonRedisInstance(RedissonClient redisson, RedisConfig config) {
+  public RedissonRedisInstance(
+      RedissonClient redisson, RedisConfig config, RedisKeyFactory keyFactory) {
     this.redisson = redisson;
     this.config = config;
+    this.keyFactory = keyFactory;
   }
 
   @Override
@@ -33,5 +39,15 @@ public final class RedissonRedisInstance implements RedisInstance {
     }
     throw new IllegalStateException(
         "Ping is not supported for client type: " + config.getClientType());
+  }
+
+  @Override
+  public <V> BlockingQueue<V> getBlockingQueue(String name) {
+    return redisson.getBlockingQueue(keyFactory.build(name));
+  }
+
+  @Override
+  public <V> BlockingDeque<V> getBlockingDeque(String name) {
+    return redisson.getBlockingDeque(keyFactory.build(name));
   }
 }

--- a/src/test/java/io/vertx/spi/cluster/redis/impl/ITRedisInstance.java
+++ b/src/test/java/io/vertx/spi/cluster/redis/impl/ITRedisInstance.java
@@ -70,13 +70,13 @@ class ITRedisInstance {
   }
 
   @Test
-  void getRedisInstanceFromInterface() {
-    assertTrue(RedisInstance.getInstance(vertx).isPresent());
+  void createFromInterface() {
+    assertTrue(RedisInstance.create(vertx).isPresent());
   }
 
   @Test
-  void getEmptyRedisInstanceFromInterface() {
-    assertFalse(RedisInstance.getInstance(null).isPresent());
+  void createEmptyFromInterface() {
+    assertFalse(RedisInstance.create(null).isPresent());
   }
 
   @Test

--- a/src/test/java/io/vertx/spi/cluster/redis/impl/ITRedisInstance.java
+++ b/src/test/java/io/vertx/spi/cluster/redis/impl/ITRedisInstance.java
@@ -4,6 +4,7 @@ import static com.jayway.awaitility.Awaitility.await;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.vertx.core.Vertx;
@@ -17,6 +18,8 @@ import io.vertx.spi.cluster.redis.config.MapConfig;
 import io.vertx.spi.cluster.redis.config.RedisConfig;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -64,6 +67,16 @@ class ITRedisInstance {
   void getRedisInstance() {
     assertTrue(clusterManager.isActive());
     assertTrue(clusterManager.getRedisInstance().isPresent());
+  }
+
+  @Test
+  void getRedisInstanceFromInterface() {
+    assertTrue(RedisInstance.getInstance(vertx).isPresent());
+  }
+
+  @Test
+  void getEmptyRedisInstanceFromInterface() {
+    assertFalse(RedisInstance.getInstance(null).isPresent());
   }
 
   @Test
@@ -150,10 +163,34 @@ class ITRedisInstance {
     assertThat(values2).hasSameElementsAs(asList("3", "4", "5"));
   }
 
+  private RedisInstance redisInstance() {
+    return clusterManager.getRedisInstance().orElseThrow(IllegalStateException::new);
+  }
+
   @Test
   void ping() {
-    RedisInstance redisInstance =
-        clusterManager.getRedisInstance().orElseThrow(IllegalStateException::new);
-    assertTrue(redisInstance.ping());
+    assertTrue(redisInstance().ping());
+  }
+
+  @Test
+  void blockingQueue() throws InterruptedException {
+    BlockingQueue<String> queue = redisInstance().getBlockingQueue("testQueue");
+    assertNotNull(queue);
+    queue.add("1");
+    queue.add("2");
+
+    assertThat(queue.take()).isEqualTo("1");
+    assertThat(queue.take()).isEqualTo("2");
+  }
+
+  @Test
+  void blockingDeque() {
+    BlockingDeque<String> deque = redisInstance().getBlockingDeque("testDeque");
+    assertNotNull(deque);
+    deque.push("1");
+    deque.push("2");
+
+    assertThat(deque.pop()).isEqualTo("2");
+    assertThat(deque.pop()).isEqualTo("1");
   }
 }


### PR DESCRIPTION
Expose `java.util.concurrent` data types backed by Redis on the `RedisInstance` API.