### PR TITLE
feat: Support data grid without a cluster manager

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/redis/ClusterHealthCheck.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/ClusterHealthCheck.java
@@ -22,18 +22,17 @@ public interface ClusterHealthCheck {
    */
   static Handler<Promise<Status>> createProcedure(Vertx vertx) {
     Objects.requireNonNull(vertx);
-    return healthCheckPromise -> {
-      vertx.executeBlocking(
-          promise -> {
-            VertxInternal vertxInternal = (VertxInternal) Vertx.currentContext().owner();
-            RedisClusterManager clusterManager =
-                (RedisClusterManager) vertxInternal.getClusterManager();
-            boolean connected =
-                clusterManager.getRedisInstance().map(RedisInstance::ping).orElse(false);
-            promise.complete(new Status().setOk(connected));
-          },
-          false,
-          healthCheckPromise);
-    };
+    return healthCheckPromise ->
+        vertx.executeBlocking(
+            promise -> {
+              VertxInternal vertxInternal = (VertxInternal) Vertx.currentContext().owner();
+              RedisClusterManager clusterManager =
+                  (RedisClusterManager) vertxInternal.getClusterManager();
+              boolean connected =
+                  clusterManager.getRedisInstance().map(RedisInstance::ping).orElse(false);
+              promise.complete(new Status().setOk(connected));
+            },
+            false,
+            healthCheckPromise);
   }
 }

--- a/src/main/java/io/vertx/spi/cluster/redis/RedisClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/RedisClusterManager.java
@@ -1,12 +1,9 @@
 package io.vertx.spi.cluster.redis;
 
 import static java.util.Collections.singleton;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.VertxException;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.shareddata.AsyncMap;
 import io.vertx.core.shareddata.Counter;
@@ -16,35 +13,17 @@ import io.vertx.core.spi.cluster.NodeInfo;
 import io.vertx.core.spi.cluster.NodeListener;
 import io.vertx.core.spi.cluster.NodeSelector;
 import io.vertx.core.spi.cluster.RegistrationInfo;
-import io.vertx.spi.cluster.redis.config.ClientType;
-import io.vertx.spi.cluster.redis.config.LockConfig;
 import io.vertx.spi.cluster.redis.config.RedisConfig;
 import io.vertx.spi.cluster.redis.impl.NodeInfoCatalog;
 import io.vertx.spi.cluster.redis.impl.NodeInfoCatalogListener;
-import io.vertx.spi.cluster.redis.impl.RedisKeyFactory;
+import io.vertx.spi.cluster.redis.impl.RedissonContext;
 import io.vertx.spi.cluster.redis.impl.RedissonRedisInstance;
 import io.vertx.spi.cluster.redis.impl.SubscriptionCatalog;
-import io.vertx.spi.cluster.redis.impl.codec.RedisMapCodec;
-import io.vertx.spi.cluster.redis.impl.shareddata.RedisAsyncMap;
-import io.vertx.spi.cluster.redis.impl.shareddata.RedisCounter;
-import io.vertx.spi.cluster.redis.impl.shareddata.RedisLock;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.redisson.Redisson;
-import org.redisson.api.EvictionMode;
-import org.redisson.api.RMapCache;
-import org.redisson.api.RPermitExpirableSemaphore;
-import org.redisson.api.RSemaphore;
-import org.redisson.api.RedissonClient;
-import org.redisson.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +35,7 @@ import org.slf4j.LoggerFactory;
 public class RedisClusterManager implements ClusterManager, NodeInfoCatalogListener {
 
   private static final Logger log = LoggerFactory.getLogger(RedisClusterManager.class);
+  private final RedissonContext redissonContext;
 
   private VertxInternal vertx;
   private NodeSelector nodeSelector;
@@ -65,18 +45,10 @@ public class RedisClusterManager implements ClusterManager, NodeInfoCatalogListe
 
   private final AtomicBoolean active = new AtomicBoolean();
 
-  private final RedisConfig config;
-  private final Config redisConfig;
-
-  private final RedisKeyFactory keyFactory;
-  private RedissonClient redisson;
+  private RedissonRedisInstance dataGrid;
 
   private NodeInfoCatalog nodeInfoCatalog;
   private SubscriptionCatalog subscriptionCatalog;
-  private ExecutorService lockReleaseExec;
-
-  private final ConcurrentMap<String, AsyncMap<?, ?>> asyncMapCache = new ConcurrentHashMap<>();
-  private final ConcurrentMap<String, SemaphoreWrapper> locksCache = new ConcurrentHashMap<>();
 
   /**
    * Create a Redis cluster manager with default configuration from system properties or environment
@@ -102,21 +74,7 @@ public class RedisClusterManager implements ClusterManager, NodeInfoCatalogListe
    * @param dataClassLoader class loader used to restore keys and values returned from Redis
    */
   public RedisClusterManager(RedisConfig config, ClassLoader dataClassLoader) {
-    Objects.requireNonNull(dataClassLoader);
-    redisConfig = new Config();
-
-    if (config.getClientType() == ClientType.STANDALONE) {
-      redisConfig.useSingleServer().setAddress(config.getEndpoints().get(0));
-    } else {
-      throw new IllegalStateException("RedisClusterManager only supports STANDALONE client");
-    }
-
-    redisConfig.setCodec(new RedisMapCodec(dataClassLoader));
-    if (dataClassLoader != getClass().getClassLoader()) {
-      redisConfig.setUseThreadClassLoader(false);
-    }
-    keyFactory = new RedisKeyFactory(config.getKeyNamespace());
-    this.config = new RedisConfig(config);
+    redissonContext = new RedissonContext(config, dataClassLoader);
   }
 
   @Override
@@ -125,81 +83,24 @@ public class RedisClusterManager implements ClusterManager, NodeInfoCatalogListe
     this.nodeSelector = nodeSelector;
   }
 
-  private <K, V> RMapCache<K, V> getMapCache(String name) {
-    RMapCache<K, V> map = redisson.getMapCache(keyFactory.map(name));
-    log.debug("Create map '{}'", name);
-    config
-        .getMapConfig(name)
-        .ifPresent(
-            mapConfig -> {
-              log.debug("Configure map '{}' with {}", name, mapConfig);
-              map.setMaxSize(
-                  mapConfig.getMaxSize(), EvictionMode.valueOf(mapConfig.getEvictionMode().name()));
-            });
-    return map;
-  }
-
   @Override
   public <K, V> void getAsyncMap(String name, Promise<AsyncMap<K, V>> promise) {
-    @SuppressWarnings("unchecked")
-    AsyncMap<K, V> map =
-        (AsyncMap<K, V>)
-            asyncMapCache.computeIfAbsent(
-                name, key -> new RedisAsyncMap<>(vertx, getMapCache(key)));
-    promise.complete(map);
+    promise.complete(dataGrid.getAsyncMap(name));
   }
 
   @Override
   public <K, V> Map<K, V> getSyncMap(String name) {
-    return getMapCache(name);
-  }
-
-  private SemaphoreWrapper createSemaphore(String name) {
-    int leaseTime = config.getLockConfig(name).map(LockConfig::getLeaseTime).orElse(-1);
-    if (leaseTime == -1) {
-      log.debug("Create semaphore '{}'", name);
-      RSemaphore semaphore = redisson.getSemaphore(keyFactory.lock(name));
-      semaphore.trySetPermits(1);
-      return new SemaphoreWrapper(semaphore);
-    }
-
-    log.debug("Create semaphore '{}' with leaseTime={}", name, leaseTime);
-    RPermitExpirableSemaphore semaphore =
-        redisson.getPermitExpirableSemaphore(keyFactory.lock(name));
-    semaphore.trySetPermits(1);
-    return new SemaphoreWrapper(semaphore, leaseTime);
+    return dataGrid.getMap(name);
   }
 
   @Override
   public void getLockWithTimeout(String name, long timeout, Promise<Lock> promise) {
-    vertx.executeBlocking(
-        prom -> {
-          SemaphoreWrapper semaphore = locksCache.computeIfAbsent(name, this::createSemaphore);
-          RedisLock lock;
-          long remaining = timeout;
-          do {
-            long start = System.nanoTime();
-            try {
-              lock = semaphore.tryAcquire(remaining, lockReleaseExec);
-            } catch (InterruptedException e) {
-              Thread.currentThread().interrupt();
-              throw new VertxException("Interrupted while waiting for lock.", e);
-            }
-            remaining = remaining - MILLISECONDS.convert(System.nanoTime() - start, NANOSECONDS);
-          } while (lock == null && remaining > 0);
-          if (lock != null) {
-            prom.complete(lock);
-          } else {
-            throw new VertxException("Timed out waiting to get lock " + name);
-          }
-        },
-        false,
-        promise);
+    dataGrid.getLockWithTimeout(name, timeout).onComplete(promise);
   }
 
   @Override
   public void getCounter(String name, Promise<Counter> promise) {
-    promise.complete(new RedisCounter(vertx, redisson.getAtomicLong(keyFactory.counter(name))));
+    promise.complete(dataGrid.getCounter(name));
   }
 
   @Override
@@ -260,14 +161,18 @@ public class RedisClusterManager implements ClusterManager, NodeInfoCatalogListe
           if (active.compareAndSet(false, true)) {
             synchronized (this) {
               nodeId = UUID.randomUUID();
-              lockReleaseExec =
-                  Executors.newCachedThreadPool(
-                      r -> new Thread(r, "vertx-redis-service-release-lock-thread"));
 
-              redisson = Redisson.create(redisConfig);
+              dataGrid = new RedissonRedisInstance(vertx, redissonContext);
               nodeInfoCatalog =
-                  new NodeInfoCatalog(vertx, redisson, keyFactory, nodeId.toString(), this);
-              subscriptionCatalog = new SubscriptionCatalog(redisson, keyFactory, nodeSelector);
+                  new NodeInfoCatalog(
+                      vertx,
+                      redissonContext.client(),
+                      redissonContext.keyFactory(),
+                      nodeId.toString(),
+                      this);
+              subscriptionCatalog =
+                  new SubscriptionCatalog(
+                      redissonContext.client(), redissonContext.keyFactory(), nodeSelector);
             }
           } else {
             log.warn("Already activated, nodeId: {}", nodeId);
@@ -322,8 +227,6 @@ public class RedisClusterManager implements ClusterManager, NodeInfoCatalogListe
           if (active.compareAndSet(true, false)) {
             synchronized (RedisClusterManager.this) {
               try {
-                lockReleaseExec.shutdown();
-
                 // Stop catalog services.
                 subscriptionCatalog.close();
                 nodeInfoCatalog.close();
@@ -332,8 +235,8 @@ public class RedisClusterManager implements ClusterManager, NodeInfoCatalogListe
                 subscriptionCatalog.removeAllForNodes(singleton(nodeId.toString()));
                 nodeInfoCatalog.remove(nodeId.toString());
 
-                redisson.shutdown();
-                redisson = null;
+                // Disconnect from Redis
+                redissonContext.shutdown();
               } catch (Exception e) {
                 prom.fail(e);
               }
@@ -390,46 +293,6 @@ public class RedisClusterManager implements ClusterManager, NodeInfoCatalogListe
     if (!isActive()) {
       return Optional.empty();
     }
-    return Optional.of(new RedissonRedisInstance(redisson, config, keyFactory));
-  }
-
-  /** A redis semaphore wrapper that supports lock lease time when configured. */
-  private static class SemaphoreWrapper {
-    private RPermitExpirableSemaphore permitSemaphore;
-    private RSemaphore semaphore;
-    private int leaseTime;
-
-    private SemaphoreWrapper(RSemaphore semaphore) {
-      this.semaphore = semaphore;
-    }
-
-    private SemaphoreWrapper(RPermitExpirableSemaphore semaphore, int leaseTime) {
-      this.permitSemaphore = semaphore;
-      this.leaseTime = leaseTime;
-    }
-
-    /**
-     * Try to acquire a redis lock.
-     *
-     * @param waitTime max wait time in milliseconds
-     * @param lockReleaseExec lock release thread
-     * @return teh acquired lock or <code>null</code> if unsuccessful
-     * @throws InterruptedException if interrupted while waiting for lock
-     */
-    public RedisLock tryAcquire(long waitTime, ExecutorService lockReleaseExec)
-        throws InterruptedException {
-      RedisLock lock = null;
-      if (semaphore != null) {
-        if (semaphore.tryAcquire(waitTime, MILLISECONDS)) {
-          lock = new RedisLock(semaphore, lockReleaseExec);
-        }
-      } else {
-        String permitId = permitSemaphore.tryAcquire(waitTime, leaseTime, MILLISECONDS);
-        if (permitId != null) {
-          lock = new RedisLock(permitSemaphore, permitId, lockReleaseExec);
-        }
-      }
-      return lock;
-    }
+    return Optional.ofNullable(dataGrid);
   }
 }

--- a/src/main/java/io/vertx/spi/cluster/redis/RedisDataGrid.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/RedisDataGrid.java
@@ -1,0 +1,132 @@
+package io.vertx.spi.cluster.redis;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.shareddata.AsyncMap;
+import io.vertx.core.shareddata.Counter;
+import io.vertx.core.shareddata.Lock;
+import io.vertx.spi.cluster.redis.config.RedisConfig;
+import io.vertx.spi.cluster.redis.impl.RedissonContext;
+import io.vertx.spi.cluster.redis.impl.RedissonRedisInstance;
+import java.util.Map;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * Redis backed data grid. The data grid can be used without the {@link RedisClusterManager}.
+ *
+ * @author sasjo
+ */
+public interface RedisDataGrid {
+
+  /**
+   * Create a data grid backed by Redis.
+   *
+   * @param vertx the vertx context
+   * @param config the redis configuration
+   * @return a data grid backed by Redis.
+   */
+  static RedisDataGrid create(Vertx vertx, RedisConfig config) {
+    return create(vertx, config, RedisDataGrid.class.getClassLoader());
+  }
+
+  /**
+   * Create a data grid backed by Redis.
+   *
+   * @param vertx the vertx context
+   * @param config the redis configuration
+   * @param dataClassLoader class loader used to restore keys and values returned from Redis
+   * @return a data grid backed by Redis.
+   */
+  static RedisDataGrid create(Vertx vertx, RedisConfig config, ClassLoader dataClassLoader) {
+    return new RedissonRedisInstance(vertx, new RedissonContext(config, dataClassLoader));
+  }
+
+  /**
+   * Get an {@link AsyncMap} with the specified name. The map is accessible to all nodes connected
+   * to the same Redis instance and data put into the map from any node is visible to any other
+   * node.
+   *
+   * <p><strong>Warning:</strong> The map can only store data structures that can be serialized to
+   * Redis. Also keep in mind that latency of a distributed map is slower than that of a local map.
+   *
+   * @param name the name of the map
+   * @return the distributed async map.
+   * @param <K> the key type
+   * @param <V> the value type
+   */
+  <K, V> AsyncMap<K, V> getAsyncMap(String name);
+
+  /**
+   * Like {@link #getAsyncMap(String)} but exposed as a regular {@link Map}. Prefer {@link
+   * #getAsyncMap(String)} and use asynchronous API calls to not block on API calls.
+   *
+   * @param name the name of the map
+   * @return the distributed map.
+   * @param <K> the key type
+   * @param <V> the value type
+   */
+  <K, V> Map<K, V> getMap(String name);
+
+  /**
+   * Get a counter. The counter value is seen by all nodes connected to the same Redis and changes
+   * to the counter are visible to in all nodes.
+   *
+   * @param name the name of the counter
+   * @return the distributed counter.
+   */
+  Counter getCounter(String name);
+
+  /**
+   * Get an asynchronous lock with the specified name.
+   *
+   * @param name the name of the lock
+   * @return a future of the resulting lock.
+   */
+  Future<Lock> getLock(String name);
+
+  /**
+   * Like {@link #getLock(String)} but specifying a timeout. If the lock is not obtained within the
+   * timeout a failure will be sent to the handler.
+   *
+   * @param name the name of the lock
+   * @param timeout the timeout in ms
+   * @return a future of the resulting lock
+   */
+  Future<Lock> getLockWithTimeout(String name, long timeout);
+
+  /**
+   * Returns an unbounded blocking queue backed by Redis.
+   *
+   * @param <V> type of value
+   * @param name name of the queue
+   * @return A blocking queue instance.
+   */
+  <V> BlockingQueue<V> getBlockingQueue(String name);
+
+  /**
+   * Returns an unbounded blocking deque backed by Redis.
+   *
+   * @param <V> type of value
+   * @param name name of the deque
+   * @return a blocking deque instance.
+   */
+  <V> BlockingDeque<V> getBlockingDeque(String name);
+
+  /**
+   * Returns a topic backed by Redis.
+   *
+   * @param <V> type of messages in topic
+   * @param type the message type of the topic
+   * @param name the name of the topic
+   * @return a topic instance,
+   */
+  <V> Topic<V> getTopic(Class<V> type, String name);
+
+  /**
+   * Shutdown the data grid connection with Redis. After this, future operations on data grid data
+   * types will fail. Use this method to gracefully terminate the Redis connection as part of the
+   * application shutdown sequence.
+   */
+  void shutdown();
+}

--- a/src/main/java/io/vertx/spi/cluster/redis/RedisInstance.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/RedisInstance.java
@@ -4,8 +4,6 @@ import io.vertx.core.Vertx;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.spi.cluster.ClusterManager;
 import java.util.Optional;
-import java.util.concurrent.BlockingDeque;
-import java.util.concurrent.BlockingQueue;
 
 /**
  * Low-level access to distributed data types backed by Redis. Prefer Vertx shared data types over
@@ -13,7 +11,7 @@ import java.util.concurrent.BlockingQueue;
  *
  * @author sasjo
  */
-public interface RedisInstance {
+public interface RedisInstance extends RedisDataGrid {
 
   /**
    * Create a Redis instance from the {@link RedisClusterManager}. If Vertx is not using the Redis
@@ -38,22 +36,4 @@ public interface RedisInstance {
    * @return <code>true</code> if ping is successful, otherwise <code>false</code>.
    */
   boolean ping();
-
-  /**
-   * Returns an unbounded blocking queue backed by Redis.
-   *
-   * @param <V> type of value
-   * @param name name of the queue
-   * @return A blocking queue instance.
-   */
-  <V> BlockingQueue<V> getBlockingQueue(String name);
-
-  /**
-   * Returns an unbounded blocking deque backed by Redis.
-   *
-   * @param <V> type of value
-   * @param name name of the deque
-   * @return a blocking deque instance.
-   */
-  <V> BlockingDeque<V> getBlockingDeque(String name);
 }

--- a/src/main/java/io/vertx/spi/cluster/redis/Topic.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/Topic.java
@@ -1,0 +1,37 @@
+package io.vertx.spi.cluster.redis;
+
+import io.vertx.core.Future;
+
+/**
+ * Redis PubSub topic with subscription support. A topic can be used to send messages between
+ * processes. It's possible to implement similar features as with the Vertx EventBus and can be
+ * useful when broadcast behavior is desired or when cluster features are disabled.
+ *
+ * @param <T> the type of messages in the topic
+ */
+public interface Topic<T> {
+  /**
+   * Add a subscription to the topic.
+   *
+   * @param subscriber the subscriber callback
+   * @return a future that completes when the subscriber is registered
+   */
+  Future<Void> subscribe(TopicSubscriber<T> subscriber);
+
+  /**
+   * Remove a subscription from the topic. If the subscriber isn't known this becomes a no-op.
+   *
+   * @param subscriber the subscriber to remove
+   * @return a future that completes when the subscriber is unregistered
+   */
+  Future<Void> unsubscribe(TopicSubscriber<T> subscriber);
+
+  /**
+   * Publish a message to the topic. All subscribers from all processes will be notified.
+   *
+   * @param message the message to publish.
+   * @return a future that completes with the number of listeners that received the message
+   *     broadcast from Redis.
+   */
+  Future<Long> publish(T message);
+}

--- a/src/main/java/io/vertx/spi/cluster/redis/TopicSubscriber.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/TopicSubscriber.java
@@ -1,0 +1,17 @@
+package io.vertx.spi.cluster.redis;
+
+/**
+ * A subscriber for a {@link Topic}.
+ *
+ * @param <T> the type of message
+ */
+@FunctionalInterface
+public interface TopicSubscriber<T> {
+
+  /**
+   * Invoked for each message posted to the topic.
+   *
+   * @param message the message
+   */
+  void onMessage(T message);
+}

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/RedisKeyFactory.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/RedisKeyFactory.java
@@ -24,15 +24,15 @@ public class RedisKeyFactory {
     return hasNamespace ? namespace + DELIMITER + name : name;
   }
 
-  public String map(String name) {
+  String map(String name) {
     return build(name);
   }
 
-  public String lock(String name) {
+  String lock(String name) {
     return build(VERTX, "locks", name);
   }
 
-  public String counter(String name) {
+  String counter(String name) {
     return build(VERTX, "counters", name);
   }
 

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/RedisTopic.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/RedisTopic.java
@@ -1,0 +1,51 @@
+package io.vertx.spi.cluster.redis.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.spi.cluster.redis.Topic;
+import io.vertx.spi.cluster.redis.TopicSubscriber;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.redisson.api.RTopic;
+
+/**
+ * A Redisson topic with subscription support.
+ *
+ * @param <T> the type of messages in the topic
+ */
+class RedisTopic<T> implements Topic<T> {
+
+  private final Vertx vertx;
+  private final RTopic topic;
+  private final Class<T> type;
+  private final Map<TopicSubscriber<T>, Integer> subscribers = new ConcurrentHashMap<>();
+
+  RedisTopic(Vertx vertx, Class<T> type, RTopic topic) {
+    this.vertx = vertx;
+    this.type = type;
+    this.topic = topic;
+  }
+
+  @Override
+  public Future<Void> subscribe(TopicSubscriber<T> subscriber) {
+    return Future.fromCompletionStage(
+            topic.addListenerAsync(type, (channel, message) -> subscriber.onMessage(message)),
+            vertx.getOrCreateContext())
+        .onSuccess(id -> subscribers.put(subscriber, id))
+        .mapEmpty();
+  }
+
+  @Override
+  public Future<Void> unsubscribe(TopicSubscriber<T> subscriber) {
+    Integer id = subscribers.get(subscriber);
+    if (id == null) {
+      return Future.succeededFuture();
+    }
+    return Future.fromCompletionStage(topic.removeListenerAsync(id), vertx.getOrCreateContext());
+  }
+
+  @Override
+  public Future<Long> publish(T message) {
+    return Future.fromCompletionStage(topic.publishAsync(message), vertx.getOrCreateContext());
+  }
+}

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/RedissonContext.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/RedissonContext.java
@@ -1,0 +1,109 @@
+package io.vertx.spi.cluster.redis.impl;
+
+import io.vertx.core.shareddata.AsyncMap;
+import io.vertx.spi.cluster.redis.config.ClientType;
+import io.vertx.spi.cluster.redis.config.RedisConfig;
+import io.vertx.spi.cluster.redis.impl.codec.RedisMapCodec;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+
+/**
+ * Redisson context with the active Redisson client.
+ *
+ * @author sasjo
+ */
+public final class RedissonContext {
+
+  private final Config redisConfig;
+  private final RedisKeyFactory keyFactory;
+  private final RedisConfig config;
+  private final ConcurrentMap<String, AsyncMap<?, ?>> asyncMapCache = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, SemaphoreWrapper> locksCache = new ConcurrentHashMap<>();
+
+  private RedissonClient client;
+  private ExecutorService lockReleaseExec;
+
+  /**
+   * Create a new Redisson context with specified configuration.
+   *
+   * @param config the redis configuration
+   */
+  public RedissonContext(RedisConfig config) {
+    this(config, RedissonContext.class.getClassLoader());
+  }
+
+  /**
+   * Create a new Redisson context with specified configuration.
+   *
+   * @param config the redis configuration
+   * @param dataClassLoader class loader used to restore keys and values returned from Redis
+   */
+  public RedissonContext(RedisConfig config, ClassLoader dataClassLoader) {
+    Objects.requireNonNull(dataClassLoader);
+    redisConfig = new Config();
+
+    if (config.getClientType() == ClientType.STANDALONE) {
+      redisConfig.useSingleServer().setAddress(config.getEndpoints().get(0));
+    } else {
+      throw new IllegalStateException("RedissonContext only supports STANDALONE client");
+    }
+
+    redisConfig.setCodec(new RedisMapCodec(dataClassLoader));
+    if (dataClassLoader != getClass().getClassLoader()) {
+      redisConfig.setUseThreadClassLoader(false);
+    }
+    keyFactory = new RedisKeyFactory(config.getKeyNamespace());
+    this.config = new RedisConfig(config);
+  }
+
+  public RedisConfig config() {
+    return config;
+  }
+
+  public RedisKeyFactory keyFactory() {
+    return keyFactory;
+  }
+
+  public RedissonClient client() {
+    synchronized (this) {
+      if (client == null) {
+        client = Redisson.create(redisConfig);
+        lockReleaseExec =
+            Executors.newCachedThreadPool(
+                r -> new Thread(r, "vertx-redis-service-release-lock-thread"));
+      }
+      return client;
+    }
+  }
+
+  ConcurrentMap<String, SemaphoreWrapper> locksCache() {
+    return locksCache;
+  }
+
+  ConcurrentMap<String, AsyncMap<?, ?>> asyncMapCache() {
+    return asyncMapCache;
+  }
+
+  ExecutorService lockReleaseExec() {
+    return lockReleaseExec;
+  }
+
+  public void shutdown() {
+    synchronized (this) {
+      if (client != null) {
+        client.shutdown();
+        lockReleaseExec.shutdown();
+        locksCache.clear();
+        asyncMapCache.clear();
+      }
+      client = null;
+      lockReleaseExec = null;
+    }
+  }
+}

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/RedissonRedisInstance.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/RedissonRedisInstance.java
@@ -1,35 +1,64 @@
 package io.vertx.spi.cluster.redis.impl;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxException;
+import io.vertx.core.shareddata.AsyncMap;
+import io.vertx.core.shareddata.Counter;
+import io.vertx.core.shareddata.Lock;
 import io.vertx.spi.cluster.redis.RedisInstance;
+import io.vertx.spi.cluster.redis.Topic;
 import io.vertx.spi.cluster.redis.config.ClientType;
+import io.vertx.spi.cluster.redis.config.LockConfig;
 import io.vertx.spi.cluster.redis.config.RedisConfig;
+import io.vertx.spi.cluster.redis.impl.shareddata.RedisAsyncMap;
+import io.vertx.spi.cluster.redis.impl.shareddata.RedisCounter;
+import io.vertx.spi.cluster.redis.impl.shareddata.RedisLock;
+import java.util.Map;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.BlockingQueue;
+import org.redisson.api.EvictionMode;
+import org.redisson.api.RMapCache;
+import org.redisson.api.RPermitExpirableSemaphore;
+import org.redisson.api.RSemaphore;
 import org.redisson.api.RedissonClient;
 import org.redisson.api.redisnode.RedisNodes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Redis instance backed by Redisson.
  *
  * @author sasjo
+ * @see io.vertx.spi.cluster.redis.RedisClusterManager
+ * @see io.vertx.spi.cluster.redis.RedisDataGrid
  */
 public final class RedissonRedisInstance implements RedisInstance {
-  private final RedissonClient redisson;
+
+  private static final Logger log = LoggerFactory.getLogger(RedissonRedisInstance.class);
+  private static final long DEFAULT_LOCK_TIMEOUT = 10 * 1000L;
+
+  private final Vertx vertx;
   private final RedisConfig config;
   private final RedisKeyFactory keyFactory;
+  private final RedissonContext redissonContext;
+  private RedissonClient redisson;
 
   /**
    * Create a new instance.
    *
-   * @param redisson redisson client
-   * @param config redis cluster manager config
-   * @param keyFactory redis key factory
+   * @param vertx the Vertx context
+   * @param redissonContext the Redisson context
    */
-  public RedissonRedisInstance(
-      RedissonClient redisson, RedisConfig config, RedisKeyFactory keyFactory) {
-    this.redisson = redisson;
-    this.config = config;
-    this.keyFactory = keyFactory;
+  public RedissonRedisInstance(Vertx vertx, RedissonContext redissonContext) {
+    this.vertx = vertx;
+    this.redissonContext = redissonContext;
+    this.redisson = redissonContext.client();
+    this.config = redissonContext.config();
+    this.keyFactory = redissonContext.keyFactory();
   }
 
   @Override
@@ -42,6 +71,88 @@ public final class RedissonRedisInstance implements RedisInstance {
   }
 
   @Override
+  public <K, V> Map<K, V> getMap(String name) {
+    return getMapCache(name);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <K, V> AsyncMap<K, V> getAsyncMap(String name) {
+    return (AsyncMap<K, V>)
+        redissonContext
+            .asyncMapCache()
+            .computeIfAbsent(name, key -> new RedisAsyncMap<>(vertx, getMapCache(key)));
+  }
+
+  private <K, V> RMapCache<K, V> getMapCache(String name) {
+    RMapCache<K, V> map = redisson.getMapCache(keyFactory.map(name));
+    log.debug("Create map '{}'", name);
+    config
+        .getMapConfig(name)
+        .ifPresent(
+            mapConfig -> {
+              log.debug("Configure map '{}' with {}", name, mapConfig);
+              map.setMaxSize(
+                  mapConfig.getMaxSize(), EvictionMode.valueOf(mapConfig.getEvictionMode().name()));
+            });
+    return map;
+  }
+
+  @Override
+  public Counter getCounter(String name) {
+    return new RedisCounter(vertx, redisson.getAtomicLong(keyFactory.counter(name)));
+  }
+
+  @Override
+  public Future<Lock> getLock(String name) {
+    return getLockWithTimeout(name, DEFAULT_LOCK_TIMEOUT);
+  }
+
+  @Override
+  public Future<Lock> getLockWithTimeout(String name, long timeout) {
+    return vertx.executeBlocking(
+        prom -> {
+          SemaphoreWrapper semaphore =
+              redissonContext.locksCache().computeIfAbsent(name, this::createSemaphore);
+          RedisLock lock;
+          long remaining = timeout;
+          do {
+            long start = System.nanoTime();
+            try {
+              lock = semaphore.tryAcquire(remaining, redissonContext.lockReleaseExec());
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              throw new VertxException("Interrupted while waiting for lock.", e);
+            }
+            remaining = remaining - MILLISECONDS.convert(System.nanoTime() - start, NANOSECONDS);
+          } while (lock == null && remaining > 0);
+          if (lock != null) {
+            prom.complete(lock);
+          } else {
+            throw new VertxException("Timed out waiting to get lock " + name);
+          }
+        },
+        false);
+  }
+
+  private SemaphoreWrapper createSemaphore(String name) {
+    int leaseTime =
+        redissonContext.config().getLockConfig(name).map(LockConfig::getLeaseTime).orElse(-1);
+    if (leaseTime == -1) {
+      log.debug("Create semaphore '{}'", name);
+      RSemaphore semaphore = redisson.getSemaphore(keyFactory.lock(name));
+      semaphore.trySetPermits(1);
+      return new SemaphoreWrapper(semaphore);
+    }
+
+    log.debug("Create semaphore '{}' with leaseTime={}", name, leaseTime);
+    RPermitExpirableSemaphore semaphore =
+        redisson.getPermitExpirableSemaphore(keyFactory.lock(name));
+    semaphore.trySetPermits(1);
+    return new SemaphoreWrapper(semaphore, leaseTime);
+  }
+
+  @Override
   public <V> BlockingQueue<V> getBlockingQueue(String name) {
     return redisson.getBlockingQueue(keyFactory.build(name));
   }
@@ -49,5 +160,15 @@ public final class RedissonRedisInstance implements RedisInstance {
   @Override
   public <V> BlockingDeque<V> getBlockingDeque(String name) {
     return redisson.getBlockingDeque(keyFactory.build(name));
+  }
+
+  @Override
+  public <V> Topic<V> getTopic(Class<V> type, String name) {
+    return new RedisTopic<>(vertx, type, redisson.getTopic(keyFactory.build(name)));
+  }
+
+  @Override
+  public void shutdown() {
+    redissonContext.shutdown();
   }
 }

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/SemaphoreWrapper.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/SemaphoreWrapper.java
@@ -1,0 +1,48 @@
+package io.vertx.spi.cluster.redis.impl;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import io.vertx.spi.cluster.redis.impl.shareddata.RedisLock;
+import java.util.concurrent.ExecutorService;
+import org.redisson.api.RPermitExpirableSemaphore;
+import org.redisson.api.RSemaphore;
+
+/** A redis semaphore wrapper that supports lock lease time when configured. */
+class SemaphoreWrapper {
+  private RPermitExpirableSemaphore permitSemaphore;
+  private RSemaphore semaphore;
+  private int leaseTime;
+
+  SemaphoreWrapper(RSemaphore semaphore) {
+    this.semaphore = semaphore;
+  }
+
+  SemaphoreWrapper(RPermitExpirableSemaphore semaphore, int leaseTime) {
+    this.permitSemaphore = semaphore;
+    this.leaseTime = leaseTime;
+  }
+
+  /**
+   * Try to acquire a redis lock.
+   *
+   * @param waitTime max wait time in milliseconds
+   * @param lockReleaseExec lock release thread
+   * @return teh acquired lock or <code>null</code> if unsuccessful
+   * @throws InterruptedException if interrupted while waiting for lock
+   */
+  public RedisLock tryAcquire(long waitTime, ExecutorService lockReleaseExec)
+      throws InterruptedException {
+    RedisLock lock = null;
+    if (semaphore != null) {
+      if (semaphore.tryAcquire(waitTime, MILLISECONDS)) {
+        lock = new RedisLock(semaphore, lockReleaseExec);
+      }
+    } else {
+      String permitId = permitSemaphore.tryAcquire(waitTime, leaseTime, MILLISECONDS);
+      if (permitId != null) {
+        lock = new RedisLock(permitSemaphore, permitId, lockReleaseExec);
+      }
+    }
+    return lock;
+  }
+}

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/codec/ClusterSerializableCodec.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/codec/ClusterSerializableCodec.java
@@ -3,7 +3,7 @@ package io.vertx.spi.cluster.redis.impl.codec;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.shareddata.impl.ClusterSerializable;
+import io.vertx.core.shareddata.ClusterSerializable;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
Add a new `RedisDataGrid` that can be used independent of the `RedisClusterManager`. When the cluster manager is used, the data grid is available as the `RedisInstance` and through vertx`SharedData`. If no cluster manager is used, it is possible to create a data grid with `RedisDataGrid.create(RedisConfig)`. The stand alone data grid must be managed by the application itself and it should not create multiple copies as each grid is backed by its own Redis context and connection.