### PR TITLE
fix(HCC-5601): Improve resilience with Redis connection listener

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/redis/RedisClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/RedisClusterManager.java
@@ -334,7 +334,7 @@ public class RedisClusterManager implements ClusterManager, NodeInfoCatalogListe
   class ReconnectListener implements RedissonConnectionListener {
 
     /** Milliseconds to delay the reconnect after a connection is established. */
-    private static final long RECONNECT_DELAY = 5000;
+    private static final long RECONNECT_DELAY = 100;
 
     final AtomicBoolean disconnected = new AtomicBoolean(false);
     final ReentrantLock reconnectLock = new ReentrantLock();

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/RedissonConnectionListener.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/RedissonConnectionListener.java
@@ -1,0 +1,15 @@
+package io.vertx.spi.cluster.redis.impl;
+
+/**
+ * Listener for changes to the Redis connection status.
+ *
+ * @author sasjo
+ */
+public interface RedissonConnectionListener {
+
+  /** Invoked when the Redis connection is established. */
+  void onConnect();
+
+  /** Invoked when the Redis connection is lost. */
+  void onDisconnect();
+}

--- a/src/test/java/io/vertx/spi/cluster/redis/ITConnectionListener.java
+++ b/src/test/java/io/vertx/spi/cluster/redis/ITConnectionListener.java
@@ -1,0 +1,71 @@
+package io.vertx.spi.cluster.redis;
+
+import static com.jayway.awaitility.Awaitility.await;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.spi.cluster.redis.RedisClusterManager.ReconnectListener;
+import io.vertx.spi.cluster.redis.config.RedisConfig;
+import io.vertx.spi.cluster.redis.impl.RedissonContext;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class ITConnectionListener {
+
+  @Container public static GenericContainer<?> REDIS = new FixedRedisContainer();
+
+  private RedisClusterManager clusterManager;
+  private Vertx vertx;
+
+  private String redisUrl() {
+    return "redis://" + REDIS.getHost() + ":" + REDIS.getFirstMappedPort();
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    RedissonContext redissonContext =
+        new RedissonContext(new RedisConfig().addEndpoint(redisUrl()));
+    clusterManager = new RedisClusterManager(redissonContext);
+
+    VertxOptions options = new VertxOptions().setClusterManager(clusterManager);
+    Vertx.clusteredVertx(
+        options,
+        ar -> {
+          vertx = ar.result();
+        });
+    await().until(() -> vertx != null);
+  }
+
+  @Test
+  void reconnected() {
+    ReconnectListener listener = clusterManager.reconnectListener;
+    REDIS.stop();
+    await("Redis stopped").until(() -> !REDIS.isRunning());
+
+    await("Disconnected from Redis").atMost(5, TimeUnit.SECONDS).until(listener.disconnected::get);
+
+    REDIS.start();
+    await("Reconnected with Redis")
+        .atMost(20, TimeUnit.SECONDS)
+        .until(() -> !listener.disconnected.get());
+  }
+
+  /**
+   * A Redis container with a fixed host port. This is required in this test to allow us to start
+   * and stop Redis while testing connection listeners.
+   */
+  public static class FixedRedisContainer extends GenericContainer<FixedRedisContainer> {
+    public FixedRedisContainer() {
+      super(DockerImageName.parse("redis:6-alpine"));
+      withCommand("redis-server", "--save", "''");
+      withExposedPorts(6379);
+      addFixedExposedPort(6379, 6379);
+    }
+  }
+}

--- a/src/test/java/io/vertx/spi/cluster/redis/impl/ITRedisDataGrid.java
+++ b/src/test/java/io/vertx/spi/cluster/redis/impl/ITRedisDataGrid.java
@@ -1,0 +1,36 @@
+package io.vertx.spi.cluster.redis.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.vertx.core.Vertx;
+import io.vertx.spi.cluster.redis.RedisDataGrid;
+import io.vertx.spi.cluster.redis.RedisInstance;
+import io.vertx.spi.cluster.redis.RedisTestContainerFactory;
+import io.vertx.spi.cluster.redis.config.RedisConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class ITRedisDataGrid {
+  @Container public GenericContainer<?> redis = RedisTestContainerFactory.newContainer();
+
+  private RedisConfig config;
+
+  @BeforeEach
+  void beforeEach() {
+    String redisUrl = "redis://" + redis.getHost() + ":" + redis.getFirstMappedPort();
+    config = new RedisConfig().addEndpoint(redisUrl);
+  }
+
+  @Test
+  void createDataGrid() {
+    RedisDataGrid dataGrid = assertDoesNotThrow(() -> RedisDataGrid.create(Vertx.vertx(), config));
+    assertThat(dataGrid).isInstanceOf(RedisInstance.class);
+    assertTrue(((RedisInstance) dataGrid).ping());
+  }
+}


### PR DESCRIPTION
If we loose the connection to the Redis instance there's a probability that we have inconsistent information in Redis vs. all the clustered nodes. This becomes a problem when we use the event bus to make calls to verticals in other nodes as we can have stale and incorrect address information.

This fix introduces a listener for the Redis connection state. If we disconnect and then reconnect we will perform similar actions as when joining the cluster at startup.