### PR TITLE
fix: Make Redis connection listener configurable and experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ The cluster manager is possible to use with
 The manager can be configured programmatically, but the preferred option is to use the supported system properties or
 environment variables.
 
-| System Property          | Environment Variable     | Default                                  | Description                                                                                                      |
-|--------------------------|--------------------------|------------------------------------------|------------------------------------------------------------------------------------------------------------------|
-| redis.connection.address | REDIS_CONNECTION_ADDRESS | Created from other connection properties | Set the fully qualified Redis address. This is an optional property.                                             |
-| redis.connection.host    | REDIS_CONNECTION_HOST    | 127.0.0.1                                | The Redis server hostname or IP address.                                                                         |
-| redis.connection.port    | REDIS_CONNECTION_PORT    | 6379                                     | The Redis server port.                                                                                           |
-| redis.connection.scheme  | REDIS_CONNECTION_SCHEME  | redis                                    | The Redis scheme. Use <code>redis</code> for TCP and <code>rediss</code> for TLS.                                |
-| redis.key.namespace      | REDIS_KEY_NAMESPACE      |                                          | Optional namespace to prefix all keys with. This is useful if the Redis instance is shared by multiple services. |
+| System Property               | Environment Variable          | Default                                  | Description                                                                                                      |
+|-------------------------------|-------------------------------|------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| redis.connection.address      | REDIS_CONNECTION_ADDRESS      | Created from other connection properties | Set the fully qualified Redis address. This is an optional property.                                             |
+| redis.connection.host         | REDIS_CONNECTION_HOST         | 127.0.0.1                                | The Redis server hostname or IP address.                                                                         |
+| redis.connection.port         | REDIS_CONNECTION_PORT         | 6379                                     | The Redis server port.                                                                                           |
+| redis.connection.scheme       | REDIS_CONNECTION_SCHEME       | redis                                    | The Redis scheme. Use <code>redis</code> for TCP and <code>rediss</code> for TLS.                                |
+| redis.key.namespace           | REDIS_KEY_NAMESPACE           |                                          | Optional namespace to prefix all keys with. This is useful if the Redis instance is shared by multiple services. |
+| redis.use.connection.listener | REDIS_USE_CONNECTION_LISTENER | false                                    | Use a connection listener to automatically reconnect to Redis (EXPERIMENTAL).                                    |
 
 ## Development
 

--- a/src/main/java/io/vertx/spi/cluster/redis/config/RedisConfig.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/config/RedisConfig.java
@@ -39,10 +39,15 @@ public class RedisConfig {
   /** Lock configuration. */
   private final List<LockConfig> locks = new ArrayList<>();
 
+  /** Use connection listener. */
+  private boolean useConnectionListener;
+
   /** Create the default configuration from existing environment variables. */
   public RedisConfig() {
     defaultEndpoint = RedisConfigProps.getDefaultEndpoint().toASCIIString();
     keyNamespace = RedisConfigProps.getPropertyValue("redis.key.namespace");
+    useConnectionListener =
+        Boolean.parseBoolean(RedisConfigProps.getPropertyValue("redis.use.connection.listener"));
   }
 
   /**
@@ -55,6 +60,7 @@ public class RedisConfig {
     type = other.type;
     keyNamespace = other.keyNamespace;
     endpoints = new ArrayList<>(other.endpoints);
+    useConnectionListener = other.useConnectionListener;
     other.maps.stream().map(MapConfig::new).forEach(maps::add);
     other.locks.stream().map(LockConfig::new).forEach(locks::add);
   }
@@ -212,6 +218,29 @@ public class RedisConfig {
   }
 
   /**
+   * Returns the connection listener flag.
+   *
+   * @return <code>true</code> if a connection listener should be used to track Redis connection
+   *     state.
+   */
+  public boolean isUseConnectionListener() {
+    return useConnectionListener;
+  }
+
+  /**
+   * Set the use connection listener flag. If set, a connection listener will be registered to track
+   * the Redis connection state.
+   *
+   * @param useConnectionListener <code>true</code> to use a connection listener, otherwise <code>
+   *     false</code>
+   * @return fluent self
+   */
+  public RedisConfig setUseConnectionListener(boolean useConnectionListener) {
+    this.useConnectionListener = useConnectionListener;
+    return this;
+  }
+
+  /**
    * Converts this object to JSON notation.
    *
    * @return JSON
@@ -231,13 +260,15 @@ public class RedisConfig {
         && Objects.equals(keyNamespace, that.keyNamespace)
         && defaultEndpoint.equals(that.defaultEndpoint)
         && endpoints.equals(that.endpoints)
+        && useConnectionListener == that.useConnectionListener
         && maps.equals(that.maps)
         && locks.equals(that.locks);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, keyNamespace, defaultEndpoint, endpoints, maps, locks);
+    return Objects.hash(
+        type, keyNamespace, defaultEndpoint, endpoints, useConnectionListener, maps, locks);
   }
 
   @Override

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/RedissonContext.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/RedissonContext.java
@@ -59,7 +59,9 @@ public final class RedissonContext {
       throw new IllegalStateException("RedissonContext only supports STANDALONE client");
     }
 
-    redisConfig.setConnectionListener(new DelegateConnectionListener());
+    if (config.isUseConnectionListener()) {
+      redisConfig.setConnectionListener(new DelegateConnectionListener());
+    }
     redisConfig.setCodec(new RedisMapCodec(dataClassLoader));
     if (dataClassLoader != getClass().getClassLoader()) {
       redisConfig.setUseThreadClassLoader(false);
@@ -114,11 +116,15 @@ public final class RedissonContext {
   }
 
   public void addConnectionListener(RedissonConnectionListener listener) {
-    listeners.addIfAbsent(listener);
+    if (config.isUseConnectionListener()) {
+      listeners.addIfAbsent(listener);
+    }
   }
 
   public void removeConnectionListener(RedissonConnectionListener listener) {
-    listeners.remove(listener);
+    if (config.isUseConnectionListener()) {
+      listeners.remove(listener);
+    }
   }
 
   private class DelegateConnectionListener implements ConnectionListener {

--- a/src/test/java/io/vertx/spi/cluster/redis/config/RedisConfigTest.java
+++ b/src/test/java/io/vertx/spi/cluster/redis/config/RedisConfigTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.vertx.core.json.JsonObject;
 import java.util.regex.Pattern;
@@ -29,15 +30,18 @@ class RedisConfigTest {
       System.setProperty("redis.connection.host", "localhost");
       System.setProperty("redis.connection.port", "8080");
       System.setProperty("redis.key.namespace", "test");
+      System.setProperty("redis.use.connection.listener", "true");
 
       RedisConfig config = new RedisConfig();
       assertEquals("test", config.getKeyNamespace());
       assertEquals(singletonList("rediss://localhost:8080"), config.getEndpoints());
+      assertTrue(config.isUseConnectionListener());
     } finally {
       System.clearProperty("redis.connection.scheme");
       System.clearProperty("redis.connection.host");
       System.clearProperty("redis.connection.port");
       System.clearProperty("redis.key.namespace");
+      System.clearProperty("redis.use.connection.listener");
     }
   }
 
@@ -145,5 +149,13 @@ class RedisConfigTest {
   void lockConfigToString() {
     String toString = assertDoesNotThrow(() -> new LockConfig("test").toString());
     assertThat(toString).contains("leaseTime=-1");
+  }
+
+  @Test
+  void useConnectionListenerEnabled() {
+    RedisConfig expected = complexConfig().setUseConnectionListener(true);
+    assertTrue(expected.isUseConnectionListener());
+    RedisConfig actual = new RedisConfig(expected.toJson());
+    assertEquals(expected, actual);
   }
 }


### PR DESCRIPTION
The listener must now be enabled with `REDIS_USE_CONNECTION_LISTENER=true` environment variable.