### PR TITLE
fix: Break node catalog member removal loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ environment variables.
 
 ## Development
 
-The project is built with OpenJDK 8 and Maven.
+The project is built with OpenJDK 21 and Maven.
 
 To build the project with all tests, run
 ```bash
@@ -46,4 +46,9 @@ Ensure you install and enable [pre-commit](https://pre-commit.com) before commit
 
 ```bash
 pre-commit install -t pre-commit -t commit-msg
+```
+
+When developing your applications, it can be handy to spin up a Redis with Docker.
+```bash
+docker run --rm -it -p 6379:6379 redis:6-alpine redis-server --save ''
 ```

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/CloseableLock.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/CloseableLock.java
@@ -1,0 +1,50 @@
+package io.vertx.spi.cluster.redis.impl;
+
+import java.util.concurrent.locks.Lock;
+
+/**
+ * A try-with-resource lock that will be claimed on creation and released with the resource block.
+ *
+ * <pre>
+ *   Lock lock = new ReentrantLock();
+ *   // ...
+ *   try (var ignored = CloseableLock.lock(lock)) {
+ *     // critical section.
+ *   }
+ * </pre>
+ *
+ * @author sasjo
+ */
+public final class CloseableLock implements AutoCloseable {
+
+  private final Lock lock;
+
+  /**
+   * Claim the given <code>lock</code>. The returned resource can be used in a try-with-resource
+   * block to automatically release the lock with the resource block.
+   *
+   * <pre>
+   *   try (var ignored = CloseableLock.lock(lock)) {
+   *     // critical section.
+   *   }
+   * </pre>
+   *
+   * @param lock the lock to claim
+   * @return an auto closeable lock.
+   * @throws NullPointerException if lock is null
+   */
+  public static CloseableLock lock(Lock lock) {
+    return new CloseableLock(lock);
+  }
+
+  private CloseableLock(Lock lock) {
+    this.lock = lock;
+    this.lock.lock();
+  }
+
+  /** Release the lock. */
+  @Override
+  public void close() {
+    lock.unlock();
+  }
+}

--- a/src/test/java/io/vertx/spi/cluster/redis/impl/CloseableLockTest.java
+++ b/src/test/java/io/vertx/spi/cluster/redis/impl/CloseableLockTest.java
@@ -1,0 +1,25 @@
+package io.vertx.spi.cluster.redis.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.locks.Lock;
+import org.junit.jupiter.api.Test;
+
+class CloseableLockTest {
+
+  @Test
+  void tryWithResourceLock() {
+    Lock lock = mock(Lock.class);
+    try (var ignored = CloseableLock.lock(lock)) {
+      verify(lock).lock();
+    }
+    verify(lock).unlock();
+  }
+
+  @Test
+  void throwsNullPointerOnNullLock() {
+    assertThrows(NullPointerException.class, () -> CloseableLock.lock(null));
+  }
+}


### PR DESCRIPTION
Fix to stabilize cluster when members are removed. The callback for `memberRemoved` should not modify the node map. Doing so will destabilize the cluster node map and we can enter a loop when a node is adding itself while also being removed by some other node (or by itself).

The fix also improves the node keep-alive by updating both key and value at a scheduled interval. This ensures that we don't depend on the key to exist in Redis for the keep alive to work.