### PR TITLE
feat(HCC-8367): Container backed by the Redis bucket

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/redis/Container.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/Container.java
@@ -1,0 +1,44 @@
+package io.vertx.spi.cluster.redis;
+
+import io.vertx.core.Future;
+import java.io.Serializable;
+import java.util.Optional;
+
+/**
+ * A settable container object which may or may not contain a non-null value.
+ *
+ * @param <T> the type of the message in the container
+ * @author Andrei Tulba
+ */
+public interface Container<T extends Serializable> {
+
+  /**
+   * Retrieves an optional containing an element stored in the container or empty if no such exists.
+   *
+   * @return a non-null optional containing the value
+   */
+  Optional<T> get();
+
+  /**
+   * Set an item to the container
+   *
+   * @param item
+   */
+  void set(T item);
+
+  /**
+   * Retrieves a future with an optional containing an element stored in the container or empty if
+   * no such exists.
+   *
+   * @return a future item stored in container
+   */
+  Future<Optional<T>> getAsync();
+
+  /**
+   * Sets asynchronously an item to the container
+   *
+   * @param item
+   * @return a future with the result of set operation
+   */
+  Future<Void> setAsync(T item);
+}

--- a/src/main/java/io/vertx/spi/cluster/redis/RedisDataGrid.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/RedisDataGrid.java
@@ -8,6 +8,7 @@ import io.vertx.core.shareddata.Lock;
 import io.vertx.spi.cluster.redis.config.RedisConfig;
 import io.vertx.spi.cluster.redis.impl.RedissonContext;
 import io.vertx.spi.cluster.redis.impl.RedissonRedisInstance;
+import java.io.Serializable;
 import java.util.Map;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.BlockingQueue;
@@ -112,6 +113,15 @@ public interface RedisDataGrid {
    * @return a blocking deque instance.
    */
   <V> BlockingDeque<V> getBlockingDeque(String name);
+
+  /**
+   * Returns a container backed by Redis.
+   *
+   * @param <V> type of value
+   * @param name name of the container
+   * @return a container instance.
+   */
+  <V extends Serializable> Container<V> getContainer(String name);
 
   /**
    * Returns a topic backed by Redis.

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/RedisContainer.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/RedisContainer.java
@@ -52,10 +52,12 @@ public class RedisContainer<T extends Serializable> implements Container<T> {
     return item == null
         ? fromCompletionStage(bucket.deleteAsync(), vertx.getOrCreateContext())
             .compose(
-                isDeleted ->
-                    isDeleted
-                        ? Future.succeededFuture()
-                        : Future.failedFuture("Failed to clean %s redis container".formatted(name)))
+                isDeleted -> {
+                  if (Boolean.TRUE.equals(isDeleted)) {
+                    return Future.succeededFuture();
+                  }
+                  return Future.failedFuture("Failed to clean %s redis container".formatted(name));
+                })
         : fromCompletionStage(bucket.setAsync(item));
   }
 }

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/RedisContainer.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/RedisContainer.java
@@ -1,0 +1,61 @@
+package io.vertx.spi.cluster.redis.impl;
+
+import static io.vertx.core.Future.fromCompletionStage;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.spi.cluster.redis.Container;
+import java.io.Serializable;
+import java.util.Optional;
+import org.redisson.api.RBucket;
+
+/**
+ * A container backed by the Redis bucket
+ *
+ * @param <T> the type of the message in the container
+ * @author Andrei Tulba
+ */
+public class RedisContainer<T extends Serializable> implements Container<T> {
+
+  private final String name;
+  private final Vertx vertx;
+  private final RBucket<T> bucket;
+
+  public RedisContainer(String name, Vertx vertx, RBucket<T> bucket) {
+    this.name = name;
+    this.vertx = vertx;
+    this.bucket = bucket;
+  }
+
+  @Override
+  public Optional<T> get() {
+    return Optional.ofNullable(bucket.get());
+  }
+
+  @Override
+  public void set(T item) {
+    if (item == null) {
+      bucket.delete();
+    } else {
+      bucket.set(item);
+    }
+  }
+
+  @Override
+  public Future<Optional<T>> getAsync() {
+    return fromCompletionStage(
+        bucket.getAsync().thenApply(Optional::ofNullable), vertx.getOrCreateContext());
+  }
+
+  @Override
+  public Future<Void> setAsync(T item) {
+    return item == null
+        ? fromCompletionStage(bucket.deleteAsync(), vertx.getOrCreateContext())
+            .compose(
+                isDeleted ->
+                    isDeleted
+                        ? Future.succeededFuture()
+                        : Future.failedFuture("Failed to clean %s redis container".formatted(name)))
+        : fromCompletionStage(bucket.setAsync(item));
+  }
+}

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/RedisContainer.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/RedisContainer.java
@@ -17,12 +17,10 @@ import org.redisson.api.RBucket;
  */
 public class RedisContainer<T extends Serializable> implements Container<T> {
 
-  private final String name;
   private final Vertx vertx;
   private final RBucket<T> bucket;
 
-  public RedisContainer(String name, Vertx vertx, RBucket<T> bucket) {
-    this.name = name;
+  public RedisContainer(Vertx vertx, RBucket<T> bucket) {
     this.vertx = vertx;
     this.bucket = bucket;
   }
@@ -34,11 +32,7 @@ public class RedisContainer<T extends Serializable> implements Container<T> {
 
   @Override
   public void set(T item) {
-    if (item == null) {
-      bucket.delete();
-    } else {
-      bucket.set(item);
-    }
+    bucket.set(item);
   }
 
   @Override
@@ -49,15 +43,6 @@ public class RedisContainer<T extends Serializable> implements Container<T> {
 
   @Override
   public Future<Void> setAsync(T item) {
-    return item == null
-        ? fromCompletionStage(bucket.deleteAsync(), vertx.getOrCreateContext())
-            .compose(
-                isDeleted -> {
-                  if (Boolean.TRUE.equals(isDeleted)) {
-                    return Future.succeededFuture();
-                  }
-                  return Future.failedFuture("Failed to clean %s redis container".formatted(name));
-                })
-        : fromCompletionStage(bucket.setAsync(item));
+    return fromCompletionStage(bucket.setAsync(item));
   }
 }

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/RedisKeyFactory.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/RedisKeyFactory.java
@@ -36,6 +36,10 @@ public class RedisKeyFactory {
     return build(VERTX, "counters", name);
   }
 
+  String container(String name) {
+    return build(VERTX, "containers", name);
+  }
+
   String topic(String name) {
     return build(VERTX, "topics", name);
   }

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/RedissonRedisInstance.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/RedissonRedisInstance.java
@@ -167,7 +167,7 @@ public final class RedissonRedisInstance implements RedisInstance {
   @Override
   public <V extends Serializable> Container<V> getContainer(String name) {
     String bucketName = keyFactory.container("name");
-    return new RedisContainer(bucketName, vertx, redisson.getBucket(bucketName));
+    return new RedisContainer<>(bucketName, vertx, redisson.getBucket(bucketName));
   }
 
   @Override

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/RedissonRedisInstance.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/RedissonRedisInstance.java
@@ -9,6 +9,7 @@ import io.vertx.core.VertxException;
 import io.vertx.core.shareddata.AsyncMap;
 import io.vertx.core.shareddata.Counter;
 import io.vertx.core.shareddata.Lock;
+import io.vertx.spi.cluster.redis.Container;
 import io.vertx.spi.cluster.redis.RedisInstance;
 import io.vertx.spi.cluster.redis.Topic;
 import io.vertx.spi.cluster.redis.config.ClientType;
@@ -17,6 +18,7 @@ import io.vertx.spi.cluster.redis.config.RedisConfig;
 import io.vertx.spi.cluster.redis.impl.shareddata.RedisAsyncMap;
 import io.vertx.spi.cluster.redis.impl.shareddata.RedisCounter;
 import io.vertx.spi.cluster.redis.impl.shareddata.RedisLock;
+import java.io.Serializable;
 import java.util.Map;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.BlockingQueue;
@@ -160,6 +162,12 @@ public final class RedissonRedisInstance implements RedisInstance {
   @Override
   public <V> BlockingDeque<V> getBlockingDeque(String name) {
     return redisson.getBlockingDeque(keyFactory.build(name));
+  }
+
+  @Override
+  public <V extends Serializable> Container<V> getContainer(String name) {
+    String bucketName = keyFactory.container("name");
+    return new RedisContainer(bucketName, vertx, redisson.getBucket(bucketName));
   }
 
   @Override

--- a/src/main/java/io/vertx/spi/cluster/redis/impl/RedissonRedisInstance.java
+++ b/src/main/java/io/vertx/spi/cluster/redis/impl/RedissonRedisInstance.java
@@ -166,8 +166,8 @@ public final class RedissonRedisInstance implements RedisInstance {
 
   @Override
   public <V extends Serializable> Container<V> getContainer(String name) {
-    String bucketName = keyFactory.container("name");
-    return new RedisContainer<>(bucketName, vertx, redisson.getBucket(bucketName));
+    String bucketName = keyFactory.container(name);
+    return new RedisContainer<>(vertx, redisson.getBucket(bucketName));
   }
 
   @Override


### PR DESCRIPTION
Expose a simple settable data structure/object holder backed by the redis buckets to cache a single object