### PR TITLE
fix: Use fair locking on cluster manager operations

### DIFF
--- a/src/main/java/com/retailsvc/vertx/spi/cluster/redis/RedisClusterManager.java
+++ b/src/main/java/com/retailsvc/vertx/spi/cluster/redis/RedisClusterManager.java
@@ -48,7 +48,7 @@ public class RedisClusterManager implements ClusterManager, NodeInfoCatalogListe
   private NodeListener nodeListener;
 
   private final AtomicBoolean active = new AtomicBoolean();
-  private final ReentrantLock lock = new ReentrantLock();
+  private final ReentrantLock lock = new ReentrantLock(true);
 
   private RedissonRedisInstance dataGrid;
 


### PR DESCRIPTION
What was wrong?
Methods like setNodeInfo and others were acquiring a ReentrantLock directly on the event loop thread, causing io.vertx.core.VertxException: Thread blocked.
This happened because the lock was acquired outside of executeBlocking, violating Vert.x’s non-blocking model.
io.vertx.core.VertxException: Thread blocked, at java.base/jdk.internal.misc.Unsafe.park(Native Method), at java.base/java.util.concurrent.locks.LockSupport.park(LockSupport.java:221), at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:754), at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:990), at java.base/java.util.concurrent.locks.ReentrantLock$Sync.lock(ReentrantLock.java:153), at java.base/java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:322), at com.retailsvc.vertx.spi.cluster.redis.impl.CloseableLock.<init>(CloseableLock.java:42), at com.retailsvc.vertx.spi.cluster.redis.impl.CloseableLock.lock(CloseableLock.java:37), at com.retailsvc.vertx.spi.cluster.redis.RedisClusterManager.setNodeInfo(RedisClusterManager.java:128), at io.vertx.core.eventbus.impl.clustered.ClusteredEventBus.lambda$null$0(ClusteredEventBus.java:121), 

Finally what've found:
vertx-redis-nodeInfo-thread is keeping and keeping and keeping the lock
but setNodeInfo wont get it for a long time. 

Solution:
use fair locking